### PR TITLE
Fix typo in command line arguments example

### DIFF
--- a/command-line-arguments.md
+++ b/command-line-arguments.md
@@ -18,7 +18,7 @@ test {
     const args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, args);
 
-    std.debug.print("Argumnets: {s}\n", .{args});
+    std.debug.print("Arguments: {s}\n", .{args});
 }
 
 ```

--- a/src/command-line-arguments.zig
+++ b/src/command-line-arguments.zig
@@ -8,5 +8,5 @@ test {
     const args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, args);
 
-    std.debug.print("Argumnets: {s}\n", .{args});
+    std.debug.print("Arguments: {s}\n", .{args});
 }


### PR DESCRIPTION
`Arguments` was written as `Argumnets`.