### PR TITLE
Update JSON tests to use 'std.testing.expectEqual'

### DIFF
--- a/json.md
+++ b/json.md
@@ -32,9 +32,9 @@ test {
     const config = try std.json.parseFromSlice(Config, std.testing.allocator, my_json, .{});
     defer config.deinit();
 
-    try std.testing.expect(config.value.vals.testing == 1);
-    try std.testing.expect(config.value.vals.production == 42);
-    try std.testing.expect(config.value.uptime == 9999);
+    try std.testing.expectEqual(@as(u8, 1), config.value.vals.testing);
+    try std.testing.expectEqual(@as(u8, 42), config.value.vals.production);
+    try std.testing.expectEqual(@as(u64, 9_999), config.value.uptime);
 }
 
 ```

--- a/src/json.zig
+++ b/src/json.zig
@@ -22,7 +22,7 @@ test {
     const config = try std.json.parseFromSlice(Config, std.testing.allocator, my_json, .{});
     defer config.deinit();
 
-    try std.testing.expect(config.value.vals.testing == 1);
-    try std.testing.expect(config.value.vals.production == 42);
-    try std.testing.expect(config.value.uptime == 9999);
+    try std.testing.expectEqual(@as(u8, 1), config.value.vals.testing);
+    try std.testing.expectEqual(@as(u8, 42), config.value.vals.production);
+    try std.testing.expectEqual(@as(u64, 9_999), config.value.uptime);
 }


### PR DESCRIPTION
Use the more descriptive 'expectEqual' testing function. This is also used in the Zig stdlib tests.