### PR TITLE
readUntilDelimiterAlloc -> streamUntilDelimiter

### DIFF
--- a/src/read-input.zig
+++ b/src/read-input.zig
@@ -8,8 +8,11 @@ test {
     const stdin = std.io.getStdIn();
 
     std.debug.print("input: ", .{});
-    const input = try stdin.reader().readUntilDelimiterAlloc(allocator, '\n', 1024);
-    defer allocator.free(input);
 
-    std.debug.print("value: {s}\n", .{input});
+    var input = std.ArrayList(u8).init(allocator);
+    defer input.deinit();
+
+    try stdin.reader().streamUntilDelimiter(input.writer(), '\n', 1024);
+
+    std.debug.print("value: {s}\n", .{input.items});
 }


### PR DESCRIPTION
Marked Deprecated in:
https://github.com/ziglang/zig/commit/5c6f111379d81cf017c8c6eaa4c7c76632acf4d6

`Reader.streamUntilDelimiter()` is used with a writer. Here, that writer is `std.ArrayList(u8)`, and the limit of 1024 characters is optional.

closes: https://github.com/zigbyexample/zigbyexample.github.io/issues/27