### PR TITLE
Fixed CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           version: master
         
-      - name: Run a multi-line script
-        run: zig build test
+      - name: Build Example Markdowns
+        run: zig build
         


### PR DESCRIPTION
Stumbled across this repo while playing around with Zig and noticed the failed build. 

Did some digging and I **think** the test option on the build tool has been deprecated after rolling back to the last passing commit tag.